### PR TITLE
 Flutterの教科書2：Instagramアプリの課題 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-
-import 'pages/feed_page.dart';
-import 'pages/my_page.dart';
+import 'package:instagram/pages/feed_page.dart';
+import 'package:instagram/pages/my_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -10,13 +9,13 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+        primarySwatch: Colors.blue,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
@@ -34,9 +33,11 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int _currentIndex = 0;
+
   final _pageWidgets = [
-    const FeedPage(),
+    FeedPage(),
     MyPage(),
+    // CarouselDemo(),
   ];
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,7 +35,7 @@ class _MyHomePageState extends State<MyHomePage> {
   int _currentIndex = 0;
 
   final _pageWidgets = [
-    FeedPage(),
+    const FeedPage(),
     MyPage(),
     // CarouselDemo(),
   ];

--- a/lib/pages/feed_page.dart
+++ b/lib/pages/feed_page.dart
@@ -82,7 +82,7 @@ class _FeedPageState extends State<FeedPage> {
                       icon: const Icon(
                         Icons.favorite_border,
                       ),
-                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      padding: const EdgeInsets.fromLTRB(5, 5, 5, 5),
                       constraints: const BoxConstraints(),
                     ),
                     IconButton(
@@ -90,7 +90,7 @@ class _FeedPageState extends State<FeedPage> {
                       icon: const Icon(
                         Icons.chat_bubble_outline_rounded,
                       ),
-                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      padding: const EdgeInsets.fromLTRB(5, 5, 5, 5),
                       constraints: const BoxConstraints(),
                     ),
                     IconButton(
@@ -98,7 +98,7 @@ class _FeedPageState extends State<FeedPage> {
                       icon: const Icon(
                         Icons.send_outlined,
                       ),
-                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      padding: const EdgeInsets.fromLTRB(5, 5, 5, 5),
                       constraints: const BoxConstraints(),
                     ),
                   ],
@@ -126,13 +126,13 @@ class _FeedPageState extends State<FeedPage> {
                     );
                   }).toList(),
                 ),
-                Spacer(),
+                const Spacer(),
                 IconButton(
                   onPressed: () {},
                   icon: const Icon(
                     Icons.bookmark_border,
                   ),
-                  padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                  padding: const EdgeInsets.fromLTRB(5, 5, 5, 5),
                   constraints: const BoxConstraints(),
                 ),
               ],

--- a/lib/pages/feed_page.dart
+++ b/lib/pages/feed_page.dart
@@ -1,12 +1,217 @@
 import 'package:flutter/material.dart';
+import 'package:carousel_slider/carousel_slider.dart';
 
-class FeedPage extends StatelessWidget {
-  const FeedPage({Key? key}) : super(key: key);
+final List<String> imgList = [
+  'https://plus.unsplash.com/premium_photo-1690366917352-3bd8bc0a0761?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+  'https://images.unsplash.com/photo-1638959773166-cee8ec38a2ee?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1915&q=80',
+  'https://images.unsplash.com/photo-1694401682625-8d2a8c6b91cf?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+];
+
+class FeedPage extends StatefulWidget {
+  const FeedPage({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _FeedPageState();
+  }
+}
+
+class _FeedPageState extends State<FeedPage> {
+  int _current = 0;
+  final CarouselController _controller = CarouselController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('フィード')),
+      appBar: AppBar(title: const Text('フィードページ')),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Image.network(
+                    'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png',
+                    width: 30,
+                    height: 30,
+                  ),
+                  const SizedBox(width: 10),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      Text(
+                        'instagram',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                      Text(
+                        'サンディエゴ',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            CarouselSlider(
+              items: imageSliders,
+              carouselController: _controller,
+              options: CarouselOptions(
+                  autoPlay: false,
+                  enlargeCenterPage: true,
+                  aspectRatio: 1.0,
+                  onPageChanged: (index, reason) {
+                    setState(() {
+                      _current = index;
+                    });
+                  }),
+            ),
+            Row(
+              children: [
+                Row(
+                  children: [
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(
+                        Icons.favorite_border,
+                      ),
+                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      constraints: const BoxConstraints(),
+                    ),
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(
+                        Icons.chat_bubble_outline_rounded,
+                      ),
+                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      constraints: const BoxConstraints(),
+                    ),
+                    IconButton(
+                      onPressed: () {},
+                      icon: const Icon(
+                        Icons.send_outlined,
+                      ),
+                      padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                      constraints: const BoxConstraints(),
+                    ),
+                  ],
+                ),
+                const SizedBox(width: 70),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: imgList.asMap().entries.map((entry) {
+                    return GestureDetector(
+                      onTap: () => _controller.animateToPage(entry.key),
+                      child: Container(
+                        width: 12.0,
+                        height: 12.0,
+                        margin: const EdgeInsets.symmetric(
+                            vertical: 8.0, horizontal: 4.0),
+                        decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color:
+                                (Theme.of(context).brightness == Brightness.dark
+                                        ? Colors.white
+                                        : Colors.black)
+                                    .withOpacity(
+                                        _current == entry.key ? 0.9 : 0.4)),
+                      ),
+                    );
+                  }).toList(),
+                ),
+                Spacer(),
+                IconButton(
+                  onPressed: () {},
+                  icon: const Icon(
+                    Icons.bookmark_border,
+                  ),
+                  padding: EdgeInsets.fromLTRB(5, 5, 5, 5),
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: const [
+                      Text(
+                        '「いいね！」',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 12,
+                        ),
+                      ),
+                      Text(
+                        '704,899件',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const Text(
+                    'Lorem Ipsum dolor sit amet、conectetur adipiscing elit、sed do eiusmod tume incidunt ut labore et dolore magnaaliqua。utenim ad ad ad minimco benias ullamco laboris nisi ut aliquip ex ea commodo commodo velit esse cillum dolore eufugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est Laborum.Lorem Ipsum dolor sit amet、conectetur adipiscing elit、sed do eiusmod tume incidunt ut labore et dolore magnaaliqua。utenim ad ad ad minimco benias ullamco laboris nisi ut aliquip ex ea commodo commodo velit esse cillum dolore eufugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est Laborum.',
+                    style: TextStyle(
+                      color: Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
+
+final List<Widget> imageSliders = imgList
+    .map((item) => Container(
+          margin: const EdgeInsets.all(5.0),
+          child: ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+              child: Stack(
+                children: <Widget>[
+                  Image.network(item, fit: BoxFit.cover, width: 600.0),
+                  Positioned(
+                    bottom: 0.0,
+                    left: 0.0,
+                    right: 0.0,
+                    child: Container(
+                      decoration: const BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [
+                            Color.fromARGB(200, 0, 0, 0),
+                            Color.fromARGB(0, 0, 0, 0)
+                          ],
+                          begin: Alignment.bottomCenter,
+                          end: Alignment.topCenter,
+                        ),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 10.0, horizontal: 20.0),
+                      child: Text(
+                        'No. ${imgList.indexOf(item)} image',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20.0,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              )),
+        ))
+    .toList();

--- a/lib/pages/feed_page.dart
+++ b/lib/pages/feed_page.dart
@@ -1,12 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 
-final List<String> imgList = [
-  'https://plus.unsplash.com/premium_photo-1690366917352-3bd8bc0a0761?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
-  'https://images.unsplash.com/photo-1638959773166-cee8ec38a2ee?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1915&q=80',
-  'https://images.unsplash.com/photo-1694401682625-8d2a8c6b91cf?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
-];
-
 class FeedPage extends StatefulWidget {
   const FeedPage({super.key});
 
@@ -19,6 +13,54 @@ class FeedPage extends StatefulWidget {
 class _FeedPageState extends State<FeedPage> {
   int _current = 0;
   final CarouselController _controller = CarouselController();
+
+  final List<String> imgList = [
+    'https://plus.unsplash.com/premium_photo-1690366917352-3bd8bc0a0761?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+    'https://images.unsplash.com/photo-1638959773166-cee8ec38a2ee?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1915&q=80',
+    'https://images.unsplash.com/photo-1694401682625-8d2a8c6b91cf?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1887&q=80',
+  ];
+
+  List<Widget> imageSliders() {
+    return imgList
+        .map((item) => Container(
+              margin: const EdgeInsets.all(5.0),
+              child: ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(5.0)),
+                  child: Stack(
+                    children: <Widget>[
+                      Image.network(item, fit: BoxFit.cover, width: 600.0),
+                      Positioned(
+                        bottom: 0.0,
+                        left: 0.0,
+                        right: 0.0,
+                        child: Container(
+                          decoration: const BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [
+                                Color.fromARGB(200, 0, 0, 0),
+                                Color.fromARGB(0, 0, 0, 0)
+                              ],
+                              begin: Alignment.bottomCenter,
+                              end: Alignment.topCenter,
+                            ),
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 10.0, horizontal: 20.0),
+                          child: Text(
+                            'No. ${imgList.indexOf(item)} image',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 20.0,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )),
+            ))
+        .toList();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -61,7 +103,7 @@ class _FeedPageState extends State<FeedPage> {
               ),
             ),
             CarouselSlider(
-              items: imageSliders,
+              items: imageSliders(),
               carouselController: _controller,
               options: CarouselOptions(
                   autoPlay: false,
@@ -175,43 +217,3 @@ class _FeedPageState extends State<FeedPage> {
     );
   }
 }
-
-final List<Widget> imageSliders = imgList
-    .map((item) => Container(
-          margin: const EdgeInsets.all(5.0),
-          child: ClipRRect(
-              borderRadius: const BorderRadius.all(Radius.circular(5.0)),
-              child: Stack(
-                children: <Widget>[
-                  Image.network(item, fit: BoxFit.cover, width: 600.0),
-                  Positioned(
-                    bottom: 0.0,
-                    left: 0.0,
-                    right: 0.0,
-                    child: Container(
-                      decoration: const BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [
-                            Color.fromARGB(200, 0, 0, 0),
-                            Color.fromARGB(0, 0, 0, 0)
-                          ],
-                          begin: Alignment.bottomCenter,
-                          end: Alignment.topCenter,
-                        ),
-                      ),
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 10.0, horizontal: 20.0),
-                      child: Text(
-                        'No. ${imgList.indexOf(item)} image',
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 20.0,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              )),
-        ))
-    .toList();

--- a/lib/pages/my_page.dart
+++ b/lib/pages/my_page.dart
@@ -8,6 +8,14 @@ class MyPage extends StatelessWidget {
     'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvoSuexQoraIJ3Xc8Qde7Y_A-7v7vfwWxveA&usqp=CAU',
     'https://www.pakutaso.com/shared/img/thumb/kaigoIMGL8113.jpg',
     'https://news.value-press.com/wp-content/uploads/interview_top_image_pakutaso.jpg',
+    'https://images.unsplash.com/photo-1694339251938-4f3309f582da?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1973&q=80',
+    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvoSuexQoraIJ3Xc8Qde7Y_A-7v7vfwWxveA&usqp=CAU',
+    'https://www.pakutaso.com/shared/img/thumb/kaigoIMGL8113.jpg',
+    'https://news.value-press.com/wp-content/uploads/interview_top_image_pakutaso.jpg',
+    'https://images.unsplash.com/photo-1694339251938-4f3309f582da?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1973&q=80',
+    'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRvoSuexQoraIJ3Xc8Qde7Y_A-7v7vfwWxveA&usqp=CAU',
+    'https://www.pakutaso.com/shared/img/thumb/kaigoIMGL8113.jpg',
+    'https://news.value-press.com/wp-content/uploads/interview_top_image_pakutaso.jpg',
   ];
 
   @override
@@ -19,17 +27,17 @@ class MyPage extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(8.0),
               child: Row(
                 children: [
                   Image.network(
-                    'https://static.xx.fbcdn.net/rsrc.php/v3/y_/r/2wPYyq9Ejn4.png',
+                    'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Instagram_logo_2016.svg/2048px-Instagram_logo_2016.svg.png',
                     width: 60,
                     height: 60,
                   ),
-                  Spacer(),
+                  const Spacer(),
                   Column(
-                    children: [
+                    children: const [
                       Text(
                         '7,041',
                         style: TextStyle(
@@ -37,14 +45,12 @@ class MyPage extends StatelessWidget {
                           fontSize: 16,
                         ),
                       ),
-                      Text(
-                        '投稿',
-                      ),
+                      Text('投稿'),
                     ],
                   ),
                   const SizedBox(width: 16),
                   Column(
-                    children: [
+                    children: const [
                       Text(
                         '4.6億',
                         style: TextStyle(
@@ -57,7 +63,7 @@ class MyPage extends StatelessWidget {
                   ),
                   const SizedBox(width: 16),
                   Column(
-                    children: [
+                    children: const [
                       Text(
                         '99',
                         style: TextStyle(
@@ -75,7 +81,7 @@ class MyPage extends StatelessWidget {
               padding: const EdgeInsets.all(8.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+                children: const [
                   Text(
                     'Instagram',
                     style: TextStyle(
@@ -108,17 +114,17 @@ class MyPage extends StatelessWidget {
                         Expanded(
                           child: OutlinedButton(
                             onPressed: () {},
-                            child: Text(
+                            style: OutlinedButton.styleFrom(
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                            ),
+                            child: const Text(
                               'フォロー中',
                               style: TextStyle(
                                 color: Colors.black,
                                 fontWeight: FontWeight.bold,
                                 fontSize: 12,
-                              ),
-                            ),
-                            style: OutlinedButton.styleFrom(
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(4),
                               ),
                             ),
                           ),
@@ -127,7 +133,11 @@ class MyPage extends StatelessWidget {
                         Expanded(
                           child: OutlinedButton(
                             onPressed: () {},
-                            child: Text(
+                            style: OutlinedButton.styleFrom(
+                                shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(4),
+                            )),
+                            child: const Text(
                               'メッセージ',
                               style: TextStyle(
                                 color: Colors.black,
@@ -135,27 +145,21 @@ class MyPage extends StatelessWidget {
                                 fontSize: 12,
                               ),
                             ),
-                            style: OutlinedButton.styleFrom(
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        OutlinedButton(
+                          onPressed: () {},
+                          style: OutlinedButton.styleFrom(
                               shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                            ),
+                            borderRadius: BorderRadius.circular(4),
+                          )),
+                          child: const Icon(
+                            Icons.keyboard_arrow_down,
+                            color: Colors.black,
                           ),
                         ),
                       ],
-                    ),
-                  ),
-                  const SizedBox(width: 4),
-                  OutlinedButton(
-                    onPressed: () {},
-                    child: Icon(
-                      Icons.keyboard_arrow_down,
-                      color: Colors.black,
-                    ),
-                    style: OutlinedButton.styleFrom(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(4),
-                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
**工夫したところ**
- carousel_sliderというカルーセル用のライブラリを使って、画像をスライド表示できるようにしました。
- 「いいね」やお「コメント」等のアイコンと、カルーセルの画像切り替えボタンを、Instagramの画面のように、同じ行に配置しました。

**難しかったところ**
- https://github.com/uni51/flu_textbook_v2_instagram/issues/2 でもご指摘いただきましたが、カルーセルで、写真画像が画面幅より小さくなってしまうのを解消するのが、やり方が良くわかりませんでした。



![スクリーンショット 2023-09-23 10 12 02](https://github.com/uni51/flu_textbook_v2_instagram/assets/14168897/379d4260-2b74-44b7-b0fa-b83139c57dd1)

